### PR TITLE
modify to send approval task to the manager and confirm tasks to the …

### DIFF
--- a/cf-onboarding-sample/onboarding/sample-data/onboard/SampleInputContext.json
+++ b/cf-onboarding-sample/onboarding/sample-data/onboard/SampleInputContext.json
@@ -1,7 +1,7 @@
 {
 	"managerId": "john.edrich@sapdemo.com",
 	"buddyId": "lorin.mathew@sapdemo.com",
-	"userId": "cgrant1",
+	"userId": "carla.grant@sapdemo.com",
 	"empData": {
 		"d": {
 			"results": [{
@@ -14,7 +14,7 @@
 				"jobTitle": "General Manager, Industries",
 				"jobCode": "Vice President, Sales (VP-SALES)",
 				"title": "VP, Sales",
-				"userId": "cgrant1",
+				"userId": "carla.grant@sapdemo.com",
 				"division": "Industries (IND)",
 				"defaultFullName": "Carla Grant",
 				"firstName": "Carla",
@@ -30,7 +30,7 @@
 							"jobTitle": "VP, Sales",
 							"countryOfCompany": "USA",
 							"jobCode": "VP-SALES",
-							"managerId": "athompson1",
+							"managerId": "john.edrich@sapdemo.com",
 							"division": "IND",
 							"company": "ACE_USA",
 							"position": "VP_SALES",
@@ -53,21 +53,20 @@
 						"__metadata": {
 							"type": "SFOData.User"
 						},
-						"userId": "dsharp1"
+						"userId": "d.sharp@sapdemo.com"
 					}, {
 						"__metadata": {
 							"type": "SFOData.User"
 						},
-						"userId": "cgrant1"
+						"userId": "carla.grant@sapdemo.com"
 					}, {
 						"__metadata": {
 							"type": "SFOData.User"
 						},
-						"userId": "sthomas1"
+						"userId": "s.thomas@sapdemo.com"
 					}]
 				}
 			}
-		},
-		"buddies": "dsharp1,cgrant1,sthomas1"
+		}
 	}
 }

--- a/cf-onboarding-sample/onboarding/workflows/onboard.workflow
+++ b/cf-onboarding-sample/onboarding/workflows/onboard.workflow
@@ -115,7 +115,7 @@
 			"priority": "MEDIUM",
 			"isHiddenInLogForParticipant": false,
 			"userInterface": "sapui5://comsapbpmworkflow.comsapbpmwusformplayer/com.sap.bpm.wus.form.player",
-			"recipientUsers": "${context.empData.buddies}, ${info.startedBy}",
+			"recipientUsers": "${context.buddyId}, ${info.startedBy}",
 			"formReference": "/forms/ConfirmOrChangeEquipment.form",
 			"userInterfaceParams": [{
 				"key": "formId",
@@ -135,7 +135,7 @@
 			"priority": "MEDIUM",
 			"isHiddenInLogForParticipant": false,
 			"userInterface": "sapui5://comsapbpmworkflow.comsapbpmwusformplayer/com.sap.bpm.wus.form.player",
-			"recipientUsers": "${info.startedBy}",
+			"recipientUsers": "${context.managerId}, ${info.startedBy}",
 			"formReference": "/forms/ApproveEquipment.form",
 			"userInterfaceParams": [{
 				"key": "formId",
@@ -155,7 +155,7 @@
 			"priority": "MEDIUM",
 			"isHiddenInLogForParticipant": false,
 			"userInterface": "sapui5://comsapbpmworkflow.comsapbpmwusformplayer/com.sap.bpm.wus.form.player",
-			"recipientUsers": "${context.empData.buddies},${info.startedBy}",
+			"recipientUsers": "${context.buddyId}, ${info.startedBy}",
 			"formReference": "/forms/AcceptWorkplace.form",
 			"userInterfaceParams": [{
 				"key": "formId",


### PR DESCRIPTION
Hi colleagues,
I just found that the sample of onboarding only sends user tasks to those who start the workflow instance, which doesn't comply with the workflow definition, and also when we use workflow API to start the workflow then no one can receive the tasks.
According to the scenario "when a new hire onboard, the equipment request first be sent to the buddy to confirm the assigned equipment, and then to the manager to approve, and finally to the buddy to confirm the readiness", I modify the "recipientUsers" of the three user tasks in "onboard.workflow", and modify the corresponding sample data in "SampleInputContext.json".
Please check if my modification can be accepted, and if so please also help to replace the cf-onboarding-sample.zip because plenty of the hands-on/workshops refer to this use case and are required to download the sample code.
Thank you so much!
BR,
Sindy Zhan